### PR TITLE
debian: remove useless maintscript

### DIFF
--- a/debian/maintscript
+++ b/debian/maintscript
@@ -1,2 +1,0 @@
-mv_conffile /etc/xivo-swagger-doc/nginx-http /etc/nginx/locations/http-available/xivo-swagger-doc 16.12
-mv_conffile /etc/xivo-swagger-doc/nginx-https /etc/nginx/locations/https-available/xivo-swagger-doc 16.12


### PR DESCRIPTION
reason: migration from 19.12 (buster) was mandatory