### PR TITLE
Pull request for fix-debian-version-compare

### DIFF
--- a/debian/maintscript
+++ b/debian/maintscript
@@ -1,1 +1,1 @@
-rm_conffile /etc/nginx/locations/http-available/xivo-swagger-doc 22.08~
+rm_conffile /etc/nginx/locations/http-available/xivo-swagger-doc 22.08

--- a/debian/postinst
+++ b/debian/postinst
@@ -9,7 +9,7 @@ case "$1" in
         if [[ -z "${previous_version}" ]]; then
             ln -sf /etc/nginx/locations/https-available/xivo-swagger-doc \
                 /etc/nginx/locations/https-enabled/xivo-swagger-doc
-        elif dpkg --compare-versions "${previous_version}" le '22.08~'; then
+        elif dpkg --compare-versions "${previous_version}" lt '22.09'; then
             rm -f /etc/nginx/locations/http-enabled/xivo-swagger-doc
         fi
     ;;


### PR DESCRIPTION
## debian: fix compare-version issue

why:
* avoid break dev environment
* with old syntax, previous_version released in 20.08 was higher than
22.08~
* use same style than other postinst

## debian: fix maintscript styling issue with version

why:
* 22.08~ is greater than 22.08~2019...
* use same syntax than other debian file
* avoid bad copy paste by other people